### PR TITLE
FISH-7048 Export javax.rmi Package from OMGAPI

### DIFF
--- a/omgapi/pom.xml
+++ b/omgapi/pom.xml
@@ -46,7 +46,7 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Export-Package>org.omg.*; version=1, com.sun.*;version=1, javax.rmi.CORBA;version=1, javax.activity;version=1</Export-Package>
+                        <Export-Package>org.omg.*; version=1, com.sun.*;version=1, javax.rmi;version=1, javax.rmi.CORBA;version=1, javax.activity;version=1</Export-Package>
                         <Import-Package>!org.omg.PortableServer.ServantLocatorPackage</Import-Package>
                         <Fragment-Host>system.bundle; extension:=framework</Fragment-Host>
                     </instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -159,8 +159,17 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>2.3.7</version>
+                    <version>4.1.0</version>
                     <extensions>true</extensions>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>manifest</goal>
+                                <goal>install</goal>
+                                <goal>deploy</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Also ports an update to the maven-bundle-plugin so that it actually builds using latest Maven and Java 8