### PR TITLE
FISH-8539 Temporary Workaround

### DIFF
--- a/csiv2-idl/pom.xml
+++ b/csiv2-idl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p7-SNAPSHOT</version>
+        <version>4.1.1.payara-p7</version>
     </parent>
 
     <artifactId>glassfish-corba-csiv2-idl</artifactId>

--- a/csiv2-idl/pom.xml
+++ b/csiv2-idl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p7</version>
+        <version>4.1.1.payara-p8-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-csiv2-idl</artifactId>

--- a/exception-annotation-processor/pom.xml
+++ b/exception-annotation-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p7-SNAPSHOT</version>
+        <version>4.1.1.payara-p7</version>
     </parent>
 
     <artifactId>exception-annotation-processor</artifactId>

--- a/exception-annotation-processor/pom.xml
+++ b/exception-annotation-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p7</version>
+        <version>4.1.1.payara-p8-SNAPSHOT</version>
     </parent>
 
     <artifactId>exception-annotation-processor</artifactId>

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p7</version>
+        <version>4.1.1.payara-p8-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-tests</artifactId>

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p7-SNAPSHOT</version>
+        <version>4.1.1.payara-p7</version>
     </parent>
 
     <artifactId>glassfish-corba-tests</artifactId>

--- a/idlj/pom.xml
+++ b/idlj/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p7</version>
+        <version>4.1.1.payara-p8-SNAPSHOT</version>
     </parent>
 
     <artifactId>idlj</artifactId>

--- a/idlj/pom.xml
+++ b/idlj/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p7-SNAPSHOT</version>
+        <version>4.1.1.payara-p7</version>
     </parent>
 
     <artifactId>idlj</artifactId>

--- a/internal-api/pom.xml
+++ b/internal-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>glassfish-corba</artifactId>
         <groupId>org.glassfish.corba</groupId>
-        <version>4.1.1.payara-p7</version>
+        <version>4.1.1.payara-p8-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/internal-api/pom.xml
+++ b/internal-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>glassfish-corba</artifactId>
         <groupId>org.glassfish.corba</groupId>
-        <version>4.1.1.payara-p7-SNAPSHOT</version>
+        <version>4.1.1.payara-p7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/omgapi/pom.xml
+++ b/omgapi/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p7-SNAPSHOT</version>
+        <version>4.1.1.payara-p7</version>
     </parent>
 
     <artifactId>glassfish-corba-omgapi</artifactId>

--- a/omgapi/pom.xml
+++ b/omgapi/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p7</version>
+        <version>4.1.1.payara-p8-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-omgapi</artifactId>

--- a/orbmain/pom.xml
+++ b/orbmain/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p7-SNAPSHOT</version>
+        <version>4.1.1.payara-p7</version>
     </parent>
 
     <artifactId>glassfish-corba-orb</artifactId>

--- a/orbmain/pom.xml
+++ b/orbmain/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p7</version>
+        <version>4.1.1.payara-p8-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-orb</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>org.glassfish.corba</groupId>
     <artifactId>glassfish-corba</artifactId>
-    <version>4.1.1.payara-p7-SNAPSHOT</version>
+    <version>4.1.1.payara-p7</version>
     <name>ORB Implementation</name>
     <packaging>pom</packaging>
     <description>A CORBA ORB for Glassfish</description>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>org.glassfish.corba</groupId>
     <artifactId>glassfish-corba</artifactId>
-    <version>4.1.1.payara-p7</version>
+    <version>4.1.1.payara-p8-SNAPSHOT</version>
     <name>ORB Implementation</name>
     <packaging>pom</packaging>
     <description>A CORBA ORB for Glassfish</description>

--- a/pom.xml
+++ b/pom.xml
@@ -159,17 +159,8 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>4.1.0</version>
+                    <version>2.3.7</version>
                     <extensions>true</extensions>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>manifest</goal>
-                                <goal>install</goal>
-                                <goal>deploy</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/rmic/pom.xml
+++ b/rmic/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p7-SNAPSHOT</version>
+        <version>4.1.1.payara-p7</version>
     </parent>
 
     <artifactId>rmic</artifactId>

--- a/rmic/pom.xml
+++ b/rmic/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p7</version>
+        <version>4.1.1.payara-p8-SNAPSHOT</version>
     </parent>
 
     <artifactId>rmic</artifactId>


### PR DESCRIPTION
Revert to using bundle plugin 2.3.7 and Java 8u312 to compile. Compiling using more recent bundle plugin and Java subtly changes and breaks the manifest of GlassFish Corba ORB