### PR TITLE
FISH-10372: adding logs to identify deadlock

### DIFF
--- a/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
@@ -775,7 +775,6 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
                     }
                 }
             }
-
             // Add CorbaMessageMediator to ThreadPool's WorkQueue to process the
             // next fragment.
             // Although we could call messageMeditor.doWork() rather than putting
@@ -785,8 +784,8 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
             // it will be the thread that executes the Work (messageMediator)we
             // put the on the WorkQueue here.
             if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, "Before to add messageMediator={0} to the queue={1} for threadID={2}, threadName={3}, with requestId={3}",
-                        new Object[]{messageMediator, queue, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
+                logger.log(Level.FINE, "Before to add messageMediator={0}, threadID={1}, threadName={2}, with requestId={3}",
+                        new Object[]{messageMediator, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
             }
             addMessageMediatorToWorkQueue(messageMediator, requestId.toString());
         } else {

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
@@ -819,13 +819,13 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
             poolToUse = messageMediator.getThreadPoolToUse();
             poolToUseInfo(poolToUse);
             if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, "Adding messageMediator to pool={0} to add messageMediator{1} for threadID={2}, theadName={3}, requestId={4}",
-                        new Object[]{poolToUse, messageMediator, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
+                logger.log(Level.FINE, "Adding messageMediator={0} to pool={1} with threadID={2}, theadName={3}, requestId={4}",
+                        new Object[]{messageMediator, poolToUse, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
             }
             orb.getThreadPoolManager().getThreadPool(poolToUse).getWorkQueue(0).
                     addWork((MessageMediatorImpl) messageMediator);
             if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, "After adding messageMediator{0} for pool={1} with threadID={2}, theadName={3}, requestId={4}",
+                logger.log(Level.FINE, "After adding messageMediator={0} to pool={1} with threadID={2}, theadName={3}, requestId={4}",
                         new Object[]{messageMediator, poolToUse, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
             }
             Thread.currentThread().notifyAll();


### PR DESCRIPTION
Adding logs to identify deadlock. 

to enable the logs add the following value at the end of the logging properties file on the server:

`
com.sun.corba.ee.impl.protocol.level=FINE
`

then you can see the logs on the console:

![image](https://github.com/user-attachments/assets/6c777751-c88c-4598-bac0-35a94eda6f6a)
