### PR TITLE
Fish 10526 improving concurrent implementation of corba to use lock api

### DIFF
--- a/csiv2-idl/pom.xml
+++ b/csiv2-idl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p9-SNAPSHOT</version>
+        <version>4.1.1.payara-p10-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-csiv2-idl</artifactId>

--- a/csiv2-idl/pom.xml
+++ b/csiv2-idl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p9-SNAPSHOT</version>
+        <version>4.1.1.payara-p9</version>
     </parent>
 
     <artifactId>glassfish-corba-csiv2-idl</artifactId>

--- a/csiv2-idl/pom.xml
+++ b/csiv2-idl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p9</version>
+        <version>4.1.1.payara-p10-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-csiv2-idl</artifactId>

--- a/csiv2-idl/pom.xml
+++ b/csiv2-idl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p10-SNAPSHOT</version>
+        <version>4.1.1.payara-p9-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-csiv2-idl</artifactId>

--- a/exception-annotation-processor/pom.xml
+++ b/exception-annotation-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p9-SNAPSHOT</version>
+        <version>4.1.1.payara-p10-SNAPSHOT</version>
     </parent>
 
     <artifactId>exception-annotation-processor</artifactId>

--- a/exception-annotation-processor/pom.xml
+++ b/exception-annotation-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p9</version>
+        <version>4.1.1.payara-p10-SNAPSHOT</version>
     </parent>
 
     <artifactId>exception-annotation-processor</artifactId>

--- a/exception-annotation-processor/pom.xml
+++ b/exception-annotation-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p9-SNAPSHOT</version>
+        <version>4.1.1.payara-p9</version>
     </parent>
 
     <artifactId>exception-annotation-processor</artifactId>

--- a/exception-annotation-processor/pom.xml
+++ b/exception-annotation-processor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p10-SNAPSHOT</version>
+        <version>4.1.1.payara-p9-SNAPSHOT</version>
     </parent>
 
     <artifactId>exception-annotation-processor</artifactId>

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p9-SNAPSHOT</version>
+        <version>4.1.1.payara-p10-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-tests</artifactId>

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p9</version>
+        <version>4.1.1.payara-p10-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-tests</artifactId>

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p9-SNAPSHOT</version>
+        <version>4.1.1.payara-p9</version>
     </parent>
 
     <artifactId>glassfish-corba-tests</artifactId>

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p10-SNAPSHOT</version>
+        <version>4.1.1.payara-p9-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-tests</artifactId>

--- a/idlj/pom.xml
+++ b/idlj/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p9-SNAPSHOT</version>
+        <version>4.1.1.payara-p10-SNAPSHOT</version>
     </parent>
 
     <artifactId>idlj</artifactId>

--- a/idlj/pom.xml
+++ b/idlj/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p9-SNAPSHOT</version>
+        <version>4.1.1.payara-p9</version>
     </parent>
 
     <artifactId>idlj</artifactId>

--- a/idlj/pom.xml
+++ b/idlj/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p10-SNAPSHOT</version>
+        <version>4.1.1.payara-p9-SNAPSHOT</version>
     </parent>
 
     <artifactId>idlj</artifactId>

--- a/idlj/pom.xml
+++ b/idlj/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p9</version>
+        <version>4.1.1.payara-p10-SNAPSHOT</version>
     </parent>
 
     <artifactId>idlj</artifactId>

--- a/internal-api/pom.xml
+++ b/internal-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>glassfish-corba</artifactId>
         <groupId>org.glassfish.corba</groupId>
-        <version>4.1.1.payara-p9-SNAPSHOT</version>
+        <version>4.1.1.payara-p10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/internal-api/pom.xml
+++ b/internal-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>glassfish-corba</artifactId>
         <groupId>org.glassfish.corba</groupId>
-        <version>4.1.1.payara-p9-SNAPSHOT</version>
+        <version>4.1.1.payara-p9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/internal-api/pom.xml
+++ b/internal-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>glassfish-corba</artifactId>
         <groupId>org.glassfish.corba</groupId>
-        <version>4.1.1.payara-p10-SNAPSHOT</version>
+        <version>4.1.1.payara-p9-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/internal-api/pom.xml
+++ b/internal-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>glassfish-corba</artifactId>
         <groupId>org.glassfish.corba</groupId>
-        <version>4.1.1.payara-p9</version>
+        <version>4.1.1.payara-p10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/omgapi/pom.xml
+++ b/omgapi/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p9-SNAPSHOT</version>
+        <version>4.1.1.payara-p10-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-omgapi</artifactId>

--- a/omgapi/pom.xml
+++ b/omgapi/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p10-SNAPSHOT</version>
+        <version>4.1.1.payara-p9-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-omgapi</artifactId>

--- a/omgapi/pom.xml
+++ b/omgapi/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p9</version>
+        <version>4.1.1.payara-p10-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-omgapi</artifactId>

--- a/omgapi/pom.xml
+++ b/omgapi/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p9-SNAPSHOT</version>
+        <version>4.1.1.payara-p9</version>
     </parent>
 
     <artifactId>glassfish-corba-omgapi</artifactId>

--- a/orbmain/pom.xml
+++ b/orbmain/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p9-SNAPSHOT</version>
+        <version>4.1.1.payara-p10-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-orb</artifactId>

--- a/orbmain/pom.xml
+++ b/orbmain/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p9-SNAPSHOT</version>
+        <version>4.1.1.payara-p9</version>
     </parent>
 
     <artifactId>glassfish-corba-orb</artifactId>

--- a/orbmain/pom.xml
+++ b/orbmain/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p10-SNAPSHOT</version>
+        <version>4.1.1.payara-p9-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-orb</artifactId>

--- a/orbmain/pom.xml
+++ b/orbmain/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p9</version>
+        <version>4.1.1.payara-p10-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-orb</artifactId>

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
@@ -775,7 +775,6 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
                     }
                 }
             }
-
             // Add CorbaMessageMediator to ThreadPool's WorkQueue to process the
             // next fragment.
             // Although we could call messageMeditor.doWork() rather than putting
@@ -785,8 +784,8 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
             // it will be the thread that executes the Work (messageMediator)we
             // put the on the WorkQueue here.
             if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, "Before to add messageMediator={0} to the queue={1} for threadID={2}, threadName={3}, with requestId={3}",
-                        new Object[]{messageMediator, queue, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
+                logger.log(Level.FINE, "Before to add messageMediator={0}, threadID={1}, threadName={2}, with requestId={3}",
+                        new Object[]{messageMediator, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
             }
             addMessageMediatorToWorkQueue(messageMediator, requestId.toString());
         } else {

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
@@ -819,13 +819,13 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
             poolToUse = messageMediator.getThreadPoolToUse();
             poolToUseInfo(poolToUse);
             if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, "Adding messageMediator to pool={0} to add messageMediator{1} for threadID={2}, theadName={3}, requestId={4}",
-                        new Object[]{poolToUse, messageMediator, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
+                logger.log(Level.FINE, "Adding messageMediator={0} to pool={1} with threadID={2}, theadName={3}, requestId={4}",
+                        new Object[]{messageMediator, poolToUse, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
             }
             orb.getThreadPoolManager().getThreadPool(poolToUse).getWorkQueue(0).
                     addWork((MessageMediatorImpl) messageMediator);
             if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, "After adding messageMediator{0} for pool={1} with threadID={2}, theadName={3}, requestId={4}",
+                logger.log(Level.FINE, "After adding messageMediator={0} to pool={1} with threadID={2}, theadName={3}, requestId={4}",
                         new Object[]{messageMediator, poolToUse, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
             }
             Thread.currentThread().notifyAll();

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
@@ -123,15 +123,13 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
     private static final Logger logger = Logger.getLogger(MessageMediatorImpl.class.getName());
     protected static final ORBUtilSystemException wrapper = ORBUtilSystemException.self;
     protected static final InterceptorsSystemException interceptorWrapper = InterceptorsSystemException.self;
-    private static final String ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS = "com.sun.corba.ee.protocol.enablingNewFragmentProcess";
     private static final int DEFAULT_NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT = 10000;
     private static final boolean isNewFragmentProcessingSet = 
-            Boolean.parseBoolean(System.getProperty(ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS) == null ? "false" : 
-                    System.getProperty(ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS));
-    private static final String NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT = "com.sun.corba.ee.protocol.newFragmentEmptyConditionTimeout";
+            Boolean.parseBoolean(System.getProperty(ORBConstants.ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS) == null ? "false" : 
+                    System.getProperty(ORBConstants.ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS));
     private static final int newFragmentEmptyConditionTimeout = 
-            System.getProperty(NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT) == null ? DEFAULT_NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT : 
-                    Integer.parseInt(System.getProperty(NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT));
+            System.getProperty(ORBConstants.NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT) == null ? DEFAULT_NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT : 
+                    Integer.parseInt(System.getProperty(ORBConstants.NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT));
     protected ORB orb;
     protected ContactInfo contactInfo;
     protected Connection connection;

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
@@ -123,12 +123,12 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
     private static final Logger logger = Logger.getLogger(MessageMediatorImpl.class.getName());
     protected static final ORBUtilSystemException wrapper = ORBUtilSystemException.self;
     protected static final InterceptorsSystemException interceptorWrapper = InterceptorsSystemException.self;
-    private static final String ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS = "fish.payara.corba.protocol.enablingNewFragmentProcess";
+    private static final String ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS = "com.sun.corba.ee.protocol.enablingNewFragmentProcess";
     private static final int DEFAULT_NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT = 10000;
     private static final boolean isNewFragmentProcessingSet = 
             Boolean.parseBoolean(System.getProperty(ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS) == null ? "false" : 
                     System.getProperty(ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS));
-    private static final String NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT = "fish.payara.corba.protocol.newFragmentEmptyConditionTimeout";
+    private static final String NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT = "com.sun.corba.ee.protocol.newFragmentEmptyConditionTimeout";
     private static final int newFragmentEmptyConditionTimeout = 
             System.getProperty(NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT) == null ? DEFAULT_NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT : 
                     Integer.parseInt(System.getProperty(NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT));
@@ -729,10 +729,12 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
         messageInfo(message, message.getCorbaRequestId());
         connectionInfo(connection);
 
-        if (message.moreFragmentsToFollow() && !isNewFragmentProcessingSet) {
-            synchronizedProcess(message);
-        } else if (message.moreFragmentsToFollow() && isNewFragmentProcessingSet) {
-            lockProcess(message);
+        if (message.moreFragmentsToFollow()) {
+            if (!isNewFragmentProcessingSet) {
+                synchronizedProcess(message);
+            } else {
+                lockProcess(message);
+            }
         } else {
             if (logger.isLoggable(Level.FINE)) {
                 logger.log(Level.FINE, "No fragments to follow, continue with single processing for message={0} " +
@@ -842,13 +844,13 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
                         new Object[]{Thread.currentThread().getId(), Thread.currentThread().getName(),
                                 requestId, queue.size() > 0 ? queue.size() : "", connection});
             }
-            
+
             while (messageMediator == null) {
                 if (queue.size() > 0) {
                     messageMediator = queue.poll();
                 } else {
-                    if(!queueStillEmpty){
-                       break;
+                    if (!queueStillEmpty) {
+                        break;
                     }
                     queueStillEmpty = queueEmptyCondition.await(newFragmentEmptyConditionTimeout, TimeUnit.MILLISECONDS);
                 }

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
@@ -125,8 +125,8 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
     protected static final InterceptorsSystemException interceptorWrapper = InterceptorsSystemException.self;
     private static final int DEFAULT_NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT = 10000;
     private static final boolean isNewFragmentProcessingSet = 
-            Boolean.parseBoolean(System.getProperty(ORBConstants.ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS) == null ? "false" : 
-                    System.getProperty(ORBConstants.ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS));
+            Boolean.parseBoolean(System.getProperty(ORBConstants.ENABLE_NEW_FRAGMENT_CONCURRENCY_PROCESS) == null ? "false" :
+                    System.getProperty(ORBConstants.ENABLE_NEW_FRAGMENT_CONCURRENCY_PROCESS));
     private static final int newFragmentEmptyConditionTimeout = 
             System.getProperty(ORBConstants.NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT) == null ? DEFAULT_NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT : 
                     Integer.parseInt(System.getProperty(ORBConstants.NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT));

--- a/orbmain/src/main/java/com/sun/corba/ee/spi/misc/ORBConstants.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/spi/misc/ORBConstants.java
@@ -641,7 +641,7 @@ public class ORBConstants {
         + "ORBGmbalRootParentName" ;
     
     //protocol constants to enable new lock api mechanism to process fragments 
-    public static final String ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS = SUN_PREFIX + "protocol.enablingNewFragmentProcess";
+    public static final String ENABLE_NEW_FRAGMENT_CONCURRENCY_PROCESS = SUN_PREFIX + "protocol.enableNewFragmentProcess";
     public static final String NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT = SUN_PREFIX + "protocol.newFragmentEmptyConditionTimeout";
 }
 

--- a/orbmain/src/main/java/com/sun/corba/ee/spi/misc/ORBConstants.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/spi/misc/ORBConstants.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+// Portions Copyright [2025] [Payara Foundation and/or its affiliates]
+
 package com.sun.corba.ee.spi.misc;
 
 import com.sun.corba.ee.org.omg.CORBA.SUNVMCID ;

--- a/orbmain/src/main/java/com/sun/corba/ee/spi/misc/ORBConstants.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/spi/misc/ORBConstants.java
@@ -637,6 +637,10 @@ public class ORBConstants {
     // ORB's gmbal root.
     public static final String GMBAL_ROOT_PARENT_NAME = SUN_PREFIX 
         + "ORBGmbalRootParentName" ;
+    
+    //protocol constants to enable new lock api mechanism to process fragments 
+    public static final String ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS = SUN_PREFIX + "protocol.enablingNewFragmentProcess";
+    public static final String NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT = SUN_PREFIX + "protocol.newFragmentEmptyConditionTimeout";
 }
 
 // End of file.

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>org.glassfish.corba</groupId>
     <artifactId>glassfish-corba</artifactId>
-    <version>4.1.1.payara-p9-SNAPSHOT</version>
+    <version>4.1.1.payara-p10-SNAPSHOT</version>
     <name>ORB Implementation</name>
     <packaging>pom</packaging>
     <description>A CORBA ORB for Glassfish</description>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>org.glassfish.corba</groupId>
     <artifactId>glassfish-corba</artifactId>
-    <version>4.1.1.payara-p9-SNAPSHOT</version>
+    <version>4.1.1.payara-p9</version>
     <name>ORB Implementation</name>
     <packaging>pom</packaging>
     <description>A CORBA ORB for Glassfish</description>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>org.glassfish.corba</groupId>
     <artifactId>glassfish-corba</artifactId>
-    <version>4.1.1.payara-p10-SNAPSHOT</version>
+    <version>4.1.1.payara-p9-SNAPSHOT</version>
     <name>ORB Implementation</name>
     <packaging>pom</packaging>
     <description>A CORBA ORB for Glassfish</description>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>org.glassfish.corba</groupId>
     <artifactId>glassfish-corba</artifactId>
-    <version>4.1.1.payara-p9</version>
+    <version>4.1.1.payara-p10-SNAPSHOT</version>
     <name>ORB Implementation</name>
     <packaging>pom</packaging>
     <description>A CORBA ORB for Glassfish</description>

--- a/rmic/pom.xml
+++ b/rmic/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p9-SNAPSHOT</version>
+        <version>4.1.1.payara-p10-SNAPSHOT</version>
     </parent>
 
     <artifactId>rmic</artifactId>

--- a/rmic/pom.xml
+++ b/rmic/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p9-SNAPSHOT</version>
+        <version>4.1.1.payara-p9</version>
     </parent>
 
     <artifactId>rmic</artifactId>

--- a/rmic/pom.xml
+++ b/rmic/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p10-SNAPSHOT</version>
+        <version>4.1.1.payara-p9-SNAPSHOT</version>
     </parent>
 
     <artifactId>rmic</artifactId>

--- a/rmic/pom.xml
+++ b/rmic/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.1.1.payara-p9</version>
+        <version>4.1.1.payara-p10-SNAPSHOT</version>
     </parent>
 
     <artifactId>rmic</artifactId>


### PR DESCRIPTION
This is to improve the current implementation to instead of using synchronized blocks to prevent concurrent threads to access resources, now use lock api. We decided to improve because with synchronized it is hard to determine which thread access and release the resources. Here I list the advantages to use the lock api:

1. Fine-Grained control: We are doing explicit locking and unlocking, this is more precise and efficient than the implementation with synchronized
2. Use of conditions variables: This allow threads to wait for certain conditions to be met before proceeding
3. Multiple Object locking: lock can be shared among multiple class instances, allowing you to manage synchronization across
these instances more flexible

For the tests I created the following Remote EJB:

[remoteview.zip](https://github.com/user-attachments/files/18833979/remoteview.zip)

To use you need to deploy on the server and include this jar on an standalone java application, here included also:
[EJBRemoteClient5.zip](https://github.com/user-attachments/files/18833994/EJBRemoteClient5.zip)

On the Main class you will see the remote call configuration to execute the tests with multiple threads creating 300 requests to the server. Something important for the standalone application is to indicate the correct path for the modules folder and resolve all dependencies for the EJB Client call configuration:

![image](https://github.com/user-attachments/assets/54683c83-890a-428b-874e-f24e7077d019)

to enable the new implementation with locks you need to set the following property on the system:

`com.sun.corba.ee.protocol.enablingNewFragmentProcess=true`

by default this is set as false to use the synchonized mechanism

also you can set the timeout time of the internal management of the process to wait for information on the queue with the following property:

`com.sun.corba.ee.protocol.newFragmentEmptyConditionTimeout=10000`

by default this is set with 10000 milliseconds, the unit for the value is milliseconds and this value is only used when the previous property is set as true

after doing multiple calls using the reproducer now I can't see any affectation on the threads, now all of them are finishing and also the performance is not affected:

![image](https://github.com/user-attachments/assets/4b51144c-8812-4228-b076-e60bb588c8aa)


I used the following environment for testing: Payara 5, azul JDK 8, windows 11 and maven 3.8.6
