### PR TITLE
Fish 10526 improving concurrent implementation of corba to use lock api payara6

### DIFF
--- a/csiv2-idl/pom.xml
+++ b/csiv2-idl/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3</version>
+        <version>4.2.4.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-csiv2-idl</artifactId>

--- a/csiv2-idl/pom.xml
+++ b/csiv2-idl/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3-SNAPSHOT</version>
+        <version>4.2.4.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-csiv2-idl</artifactId>

--- a/csiv2-idl/pom.xml
+++ b/csiv2-idl/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p4-SNAPSHOT</version>
+        <version>4.2.4.payara-p3</version>
     </parent>
 
     <artifactId>glassfish-corba-csiv2-idl</artifactId>

--- a/csiv2-idl/pom.xml
+++ b/csiv2-idl/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p4-SNAPSHOT</version>
+        <version>4.2.4.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-csiv2-idl</artifactId>

--- a/csiv2-idl/pom.xml
+++ b/csiv2-idl/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3</version>
+        <version>4.2.4.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-csiv2-idl</artifactId>

--- a/csiv2-idl/pom.xml
+++ b/csiv2-idl/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3-SNAPSHOT</version>
+        <version>4.2.4.payara-p3</version>
     </parent>
 
     <artifactId>glassfish-corba-csiv2-idl</artifactId>

--- a/exception-annotation-processor/pom.xml
+++ b/exception-annotation-processor/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3-SNAPSHOT</version>
+        <version>4.2.4.payara-p3</version>
     </parent>
 
     <artifactId>exception-annotation-processor</artifactId>

--- a/exception-annotation-processor/pom.xml
+++ b/exception-annotation-processor/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p4-SNAPSHOT</version>
+        <version>4.2.4.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>exception-annotation-processor</artifactId>

--- a/exception-annotation-processor/pom.xml
+++ b/exception-annotation-processor/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3</version>
+        <version>4.2.4.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>exception-annotation-processor</artifactId>

--- a/exception-annotation-processor/pom.xml
+++ b/exception-annotation-processor/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3-SNAPSHOT</version>
+        <version>4.2.4.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>exception-annotation-processor</artifactId>

--- a/exception-annotation-processor/pom.xml
+++ b/exception-annotation-processor/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p4-SNAPSHOT</version>
+        <version>4.2.4.payara-p3</version>
     </parent>
 
     <artifactId>exception-annotation-processor</artifactId>

--- a/exception-annotation-processor/pom.xml
+++ b/exception-annotation-processor/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3</version>
+        <version>4.2.4.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>exception-annotation-processor</artifactId>

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3-SNAPSHOT</version>
+        <version>4.2.4.payara-p3</version>
     </parent>
 
     <artifactId>glassfish-corba-tests</artifactId>

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3</version>
+        <version>4.2.4.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-tests</artifactId>

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3</version>
+        <version>4.2.4.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-tests</artifactId>

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3-SNAPSHOT</version>
+        <version>4.2.4.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-tests</artifactId>

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p4-SNAPSHOT</version>
+        <version>4.2.4.payara-p3</version>
     </parent>
 
     <artifactId>glassfish-corba-tests</artifactId>

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p4-SNAPSHOT</version>
+        <version>4.2.4.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-tests</artifactId>

--- a/idlj/pom.xml
+++ b/idlj/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3</version>
+        <version>4.2.4.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>idlj</artifactId>

--- a/idlj/pom.xml
+++ b/idlj/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3-SNAPSHOT</version>
+        <version>4.2.4.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>idlj</artifactId>

--- a/idlj/pom.xml
+++ b/idlj/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p4-SNAPSHOT</version>
+        <version>4.2.4.payara-p3</version>
     </parent>
 
     <artifactId>idlj</artifactId>

--- a/idlj/pom.xml
+++ b/idlj/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3</version>
+        <version>4.2.4.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>idlj</artifactId>

--- a/idlj/pom.xml
+++ b/idlj/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3-SNAPSHOT</version>
+        <version>4.2.4.payara-p3</version>
     </parent>
 
     <artifactId>idlj</artifactId>

--- a/idlj/pom.xml
+++ b/idlj/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p4-SNAPSHOT</version>
+        <version>4.2.4.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>idlj</artifactId>

--- a/internal-api/pom.xml
+++ b/internal-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>glassfish-corba</artifactId>
         <groupId>org.glassfish.corba</groupId>
-        <version>4.2.4.payara-p3</version>
+        <version>4.2.4.payara-p4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/internal-api/pom.xml
+++ b/internal-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>glassfish-corba</artifactId>
         <groupId>org.glassfish.corba</groupId>
-        <version>4.2.4.payara-p3-SNAPSHOT</version>
+        <version>4.2.4.payara-p3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/internal-api/pom.xml
+++ b/internal-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>glassfish-corba</artifactId>
         <groupId>org.glassfish.corba</groupId>
-        <version>4.2.4.payara-p4-SNAPSHOT</version>
+        <version>4.2.4.payara-p3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/internal-api/pom.xml
+++ b/internal-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>glassfish-corba</artifactId>
         <groupId>org.glassfish.corba</groupId>
-        <version>4.2.4.payara-p4-SNAPSHOT</version>
+        <version>4.2.4.payara-p3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/internal-api/pom.xml
+++ b/internal-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>glassfish-corba</artifactId>
         <groupId>org.glassfish.corba</groupId>
-        <version>4.2.4.payara-p3-SNAPSHOT</version>
+        <version>4.2.4.payara-p4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/internal-api/pom.xml
+++ b/internal-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>glassfish-corba</artifactId>
         <groupId>org.glassfish.corba</groupId>
-        <version>4.2.4.payara-p3</version>
+        <version>4.2.4.payara-p3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/omgapi/pom.xml
+++ b/omgapi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3</version>
+        <version>4.2.4.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-omgapi</artifactId>

--- a/omgapi/pom.xml
+++ b/omgapi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p4-SNAPSHOT</version>
+        <version>4.2.4.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-omgapi</artifactId>

--- a/omgapi/pom.xml
+++ b/omgapi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3-SNAPSHOT</version>
+        <version>4.2.4.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-omgapi</artifactId>

--- a/omgapi/pom.xml
+++ b/omgapi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3</version>
+        <version>4.2.4.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-omgapi</artifactId>

--- a/omgapi/pom.xml
+++ b/omgapi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p4-SNAPSHOT</version>
+        <version>4.2.4.payara-p3</version>
     </parent>
 
     <artifactId>glassfish-corba-omgapi</artifactId>

--- a/omgapi/pom.xml
+++ b/omgapi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3-SNAPSHOT</version>
+        <version>4.2.4.payara-p3</version>
     </parent>
 
     <artifactId>glassfish-corba-omgapi</artifactId>

--- a/orbmain/pom.xml
+++ b/orbmain/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3</version>
+        <version>4.2.4.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-orb</artifactId>

--- a/orbmain/pom.xml
+++ b/orbmain/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3-SNAPSHOT</version>
+        <version>4.2.4.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-orb</artifactId>

--- a/orbmain/pom.xml
+++ b/orbmain/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3-SNAPSHOT</version>
+        <version>4.2.4.payara-p3</version>
     </parent>
 
     <artifactId>glassfish-corba-orb</artifactId>

--- a/orbmain/pom.xml
+++ b/orbmain/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3</version>
+        <version>4.2.4.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-orb</artifactId>

--- a/orbmain/pom.xml
+++ b/orbmain/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p4-SNAPSHOT</version>
+        <version>4.2.4.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-corba-orb</artifactId>

--- a/orbmain/pom.xml
+++ b/orbmain/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p4-SNAPSHOT</version>
+        <version>4.2.4.payara-p3</version>
     </parent>
 
     <artifactId>glassfish-corba-orb</artifactId>

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
@@ -102,8 +102,15 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
     private static final Logger logger = Logger.getLogger(MessageMediatorImpl.class.getName());
     protected static final ORBUtilSystemException wrapper = ORBUtilSystemException.self;
     protected static final InterceptorsSystemException interceptorWrapper = InterceptorsSystemException.self;
-    private static final String ENABLING_NEW_FRAGMENT_CONCURRENCY_IMPL = "org.sun.corba.ee.impl.protocol.ENABLING_NEW_FRAGMENT_CONCURRENCY_IMPL";
-    private static final boolean isNewFragmentImplSet = Boolean.parseBoolean(System.getProperty(ENABLING_NEW_FRAGMENT_CONCURRENCY_IMPL) == null ? "false" : System.getProperty(ENABLING_NEW_FRAGMENT_CONCURRENCY_IMPL));
+    private static final String ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS = "fish.payara.corba.protocol.enablingNewFragmentProcess";
+    private static final int DEFAULT_NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT = 10000;
+    private static final boolean isNewFragmentProcessingSet = 
+            Boolean.parseBoolean(System.getProperty(ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS) == null ? "false" : 
+                    System.getProperty(ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS));
+    private static final String NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT = "fish.payara.corba.protocol.newFragmentEmptyConditionTimeout";
+    private static final int newFragmentEmptyConditionTimeout = 
+            System.getProperty(NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT) == null ? DEFAULT_NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT : 
+                    Integer.parseInt(System.getProperty(NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT));
     protected ORB orb;
     protected ContactInfo contactInfo;
     protected Connection connection;
@@ -701,10 +708,10 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
         messageInfo(message, message.getCorbaRequestId());
         connectionInfo(connection);
 
-        if (message.moreFragmentsToFollow() && !isNewFragmentImplSet) {
-            legacySyncronizedProcess(message);
-        } else if (message.moreFragmentsToFollow() && isNewFragmentImplSet) {
-            newLockProcess(message);
+        if (message.moreFragmentsToFollow() && !isNewFragmentProcessingSet) {
+            synchronizedProcess(message);
+        } else if (message.moreFragmentsToFollow() && isNewFragmentProcessingSet) {
+            lockProcess(message);
         } else {
             if (logger.isLoggable(Level.FINE)) {
                 logger.log(Level.FINE, "No fragments to follow, continue with single processing for message={0} " +
@@ -723,7 +730,7 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
         }
     }
 
-    private void legacySyncronizedProcess(Message message) {
+    private void synchronizedProcess(Message message) {
         if (logger.isLoggable(Level.FINE)) {
             logger.log(Level.FINE,
                     "Processing more fragments using legacy synchronized method for message={0} for threadID={1}, threadName={2}",
@@ -789,7 +796,7 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
         addMessageMediatorToWorkQueue(messageMediator, requestId.toString());
     }
 
-    private void newLockProcess(Message message) {
+    private void lockProcess(Message message) {
         if (logger.isLoggable(Level.FINE)) {
             logger.log(Level.FINE,
                     "Processing more fragments using new lock method for message={0} for threadID={1}, threadName={2}",
@@ -822,7 +829,7 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
                     if(!queueStillEmpty){
                        break;
                     }
-                    queueStillEmpty = queueEmptyCondition.await(1000, TimeUnit.MILLISECONDS);
+                    queueStillEmpty = queueEmptyCondition.await(newFragmentEmptyConditionTimeout, TimeUnit.MILLISECONDS);
                 }
             }
         } catch (InterruptedException e) {

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
@@ -754,7 +754,6 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
                     }
                 }
             }
-
             // Add CorbaMessageMediator to ThreadPool's WorkQueue to process the
             // next fragment.
             // Although we could call messageMeditor.doWork() rather than putting
@@ -764,8 +763,8 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
             // it will be the thread that executes the Work (messageMediator)we
             // put the on the WorkQueue here.
             if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, "Before to add messageMediator={0} to the queue={1} for threadID={2}, threadName={3}, with requestId={3}",
-                        new Object[]{messageMediator, queue, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
+                logger.log(Level.FINE, "Before to add messageMediator={0}, threadID={1}, threadName={2}, with requestId={3}",
+                        new Object[]{messageMediator, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
             }
             addMessageMediatorToWorkQueue(messageMediator, requestId.toString());
         } else {

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
@@ -165,8 +165,9 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
     //
     private MessageMediatorImpl(ORB orb, Connection connection) {
         if (logger.isLoggable(Level.FINE)) {
-            logger.log(Level.FINE, "MessageMediatorImpl creation with connection={0} and orb={1}",
-                    new Object[]{connection, orb});
+            logger.log(Level.FINE, "MessageMediatorImpl creation with connection={0} " +
+                            "and orb={1} and threadID={2} and threadName={3}",
+                    new Object[]{connection, orb, Thread.currentThread().getId(), Thread.currentThread().getName()});
         }
         this.orb = orb;
         this.connection = connection;
@@ -458,7 +459,8 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
                 InetSocketAddress connAddr = (InetSocketAddress) connection.getSocketChannel().getLocalAddress();
                 IIOPAddressImplLocalServer.setHostOverride(connAddr.getHostString());
                 if (logger.isLoggable(Level.FINE)) {
-                    logger.log(Level.FINE, "Connection information inetSocketAddress={0}", connAddr);
+                    logger.log(Level.FINE, "Connection information inetSocketAddress={0}, threadId={1} and threadName={2}", 
+                            new Object[]{connAddr, Thread.currentThread().getId(), Thread.currentThread().getName()});
                 }
             }
             catch(IOException ex) {
@@ -671,7 +673,8 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
         } catch (IOException e) {
             // REVISIT - this should be handled internally.
             if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, "IOException with following message=", e.getMessage());
+                logger.log(Level.FINE, "IOException with following message={0}, threadID={1} and threadName={2}", 
+                        new Object[] {e.getMessage(), Thread.currentThread().getId(), Thread.currentThread().getName()});
             }
         } finally {
             ORBUtility.popEncVersionFromThreadLocalState();
@@ -699,8 +702,8 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
         if (message.moreFragmentsToFollow()) {
             if (logger.isLoggable(Level.FINE)) {
                 logger.log(Level.FINE,
-                        "Processing more fragments for message={0} fro threadID={1}",
-                        new Object[]{message, Thread.currentThread().getId()});
+                        "Processing more fragments for message={0} for threadID={1}, threadName={2}",
+                        new Object[]{message, Thread.currentThread().getId(), Thread.currentThread().getName()});
             }
             generalMessage("getting next fragment");
 
@@ -720,30 +723,31 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
             synchronized (queue) {
                 if (logger.isLoggable(Level.FINE)) {
                     logger.log(Level.FINE,
-                            "Thread accessing synchronized block, threadID={0} with requestId={1} and queue reference={2} and connection={3}",
-                            new Object[]{Thread.currentThread().getId(), requestId, queue.size() > 0 ? queue.element() : "", connection});
+                            "Thread accessing synchronized block, threadID={0}, threadName={1} with requestId={2} and queue reference={3} and connection={4}",
+                            new Object[]{Thread.currentThread().getId(), Thread.currentThread().getName(), 
+                                    requestId, queue.size() > 0 ? queue.element() : "", connection});
                 }
                 while (messageMediator == null) {
                     if (queue.size() > 0) {
                         messageMediator = queue.poll();
                         if (logger.isLoggable(Level.FINE)) {
-                            logger.log(Level.FINE, "Current messageMediator={0} for threadID={1}",
-                                    new Object[]{messageMediator, Thread.currentThread().getId()});
+                            logger.log(Level.FINE, "Current messageMediator={0} for threadID={1}, threadName={2}",
+                                    new Object[]{messageMediator, Thread.currentThread().getId(), Thread.currentThread().getName()});
                         }
                     } else {
                         try {
                             if (logger.isLoggable(Level.FINE)) {
                                 logger.log(Level.FINE,
-                                        "Starting to wait until available messageMediator on queue, threadID={0} " +
-                                                "and queue reference={1}",
-                                        new Object[]{Thread.currentThread().getId(), queue});
+                                        "Starting to wait until available messageMediator on queue, threadID={0}, threadName={1} " +
+                                                "and queue reference={2}",
+                                        new Object[]{Thread.currentThread().getId(), Thread.currentThread().getName(), queue});
                             }
                             queue.wait();
                         } catch (InterruptedException ex) {
                             if (logger.isLoggable(Level.FINE)) {
                                 logger.log(Level.FINE, "Throwing InterruptedException with following message={0} " +
-                                                "for threadID={1}",
-                                        new Object[]{ex.getMessage(), Thread.currentThread().getId()});
+                                                "for threadID={1}, threadName={2}",
+                                        new Object[]{ex.getMessage(), Thread.currentThread().getId(), Thread.currentThread().getName()});
                             }
                             wrapper.resumeOptimizedReadThreadInterrupted(ex);
                         }
@@ -760,14 +764,15 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
             // it will be the thread that executes the Work (messageMediator)we
             // put the on the WorkQueue here.
             if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, "Before to add messageMediator={0} to the queue={1} for threadID={2}",
-                        new Object[]{messageMediator, queue, Thread.currentThread().getId()});
+                logger.log(Level.FINE, "Before to add messageMediator={0} to the queue={1} for threadID={2}, threadName={3}",
+                        new Object[]{messageMediator, queue, Thread.currentThread().getId(), Thread.currentThread().getName()});
             }
             addMessageMediatorToWorkQueue(messageMediator);
         } else {
             if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, "No fragments to follow, continue with single processing for message={0} and threadID={1}",
-                        new Object[]{message, Thread.currentThread().getId()});
+                logger.log(Level.FINE, "No fragments to follow, continue with single processing for message={0} " +
+                                "and threadID={1}, threadName={2}",
+                        new Object[]{message, Thread.currentThread().getId(), Thread.currentThread().getName()});
             }
             if (message.getType() == Message.GIOPFragment ||
                     message.getType() == Message.GIOPCancelRequest) {
@@ -793,27 +798,27 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
             poolToUse = messageMediator.getThreadPoolToUse();
             poolToUseInfo(poolToUse);
             if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, "Getting pool={0} to add messageMediator{1} for threadID={2}",
-                        new Object[]{poolToUse, messageMediator, Thread.currentThread().getId()});
+                logger.log(Level.FINE, "Getting pool={0} to add messageMediator{1} for threadID={2}, theadName={3}",
+                        new Object[]{poolToUse, messageMediator, Thread.currentThread().getId(), Thread.currentThread().getName()});
             }
             orb.getThreadPoolManager().getThreadPool(poolToUse).getWorkQueue(0).
                     addWork((MessageMediatorImpl) messageMediator);
             if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, "After adding messageMediator{0} for pool={1} with threadID={2}",
-                        new Object[]{messageMediator, poolToUse, Thread.currentThread().getId()});
+                logger.log(Level.FINE, "After adding messageMediator{0} for pool={1} with threadID={2}, theadName={3}",
+                        new Object[]{messageMediator, poolToUse, Thread.currentThread().getId(), Thread.currentThread().getName()});
             }
         } catch (NoSuchThreadPoolException e) {
             if (logger.isLoggable(Level.FINE)) {
                 logger.log(Level.FINE, "Throwing NoSuchThreadPoolException with following message={0} " +
-                                "for threadID={1}",
-                        new Object[]{e.getMessage(), Thread.currentThread().getId()});
+                                "for threadID={1}, theadName={2}",
+                        new Object[]{e.getMessage(), Thread.currentThread().getId(), Thread.currentThread().getName()});
             }
             throwable = e;
         } catch (NoSuchWorkQueueException e) {
             if (logger.isLoggable(Level.FINE)) {
                 logger.log(Level.FINE, "Throwing NoSuchWorkQueueException with following message={0} " +
-                                "for threadID={1}",
-                        new Object[]{e.getMessage(), Thread.currentThread().getId()});
+                                "for threadID={1}, threadName={2}",
+                        new Object[]{e.getMessage(), Thread.currentThread().getId(), Thread.currentThread().getName()});
             }
             throwable = e;
         }

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
@@ -798,13 +798,13 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
             poolToUse = messageMediator.getThreadPoolToUse();
             poolToUseInfo(poolToUse);
             if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, "Adding messageMediator to pool={0} to add messageMediator{1} for threadID={2}, theadName={3}, requestId={4}",
-                        new Object[]{poolToUse, messageMediator, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
+                logger.log(Level.FINE, "Adding messageMediator={0} to pool={1} with threadID={2}, theadName={3}, requestId={4}",
+                        new Object[]{messageMediator, poolToUse, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
             }
             orb.getThreadPoolManager().getThreadPool(poolToUse).getWorkQueue(0).
                     addWork((MessageMediatorImpl) messageMediator);
             if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, "After adding messageMediator{0} for pool={1} with threadID={2}, theadName={3}, requestId={4}",
+                logger.log(Level.FINE, "After adding messageMediator={0} to pool={1} with threadID={2}, theadName={3}, requestId={4}",
                         new Object[]{messageMediator, poolToUse, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
             }
             Thread.currentThread().notifyAll();

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
@@ -731,23 +731,23 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
                     if (queue.size() > 0) {
                         messageMediator = queue.poll();
                         if (logger.isLoggable(Level.FINE)) {
-                            logger.log(Level.FINE, "Current messageMediator={0} for threadID={1}, threadName={2}",
-                                    new Object[]{messageMediator, Thread.currentThread().getId(), Thread.currentThread().getName()});
+                            logger.log(Level.FINE, "Current messageMediator={0} for threadID={1}, threadName={2}, with requestId={3}",
+                                    new Object[]{messageMediator, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
                         }
                     } else {
                         try {
                             if (logger.isLoggable(Level.FINE)) {
                                 logger.log(Level.FINE,
                                         "Starting to wait until available messageMediator on queue, threadID={0}, threadName={1} " +
-                                                "and queue reference={2}",
-                                        new Object[]{Thread.currentThread().getId(), Thread.currentThread().getName(), queue});
+                                                "and queue reference={2}, with requestId={3}",
+                                        new Object[]{Thread.currentThread().getId(), Thread.currentThread().getName(), queue, requestId});
                             }
-                            queue.wait();
+                            queue.wait(1000);
                         } catch (InterruptedException ex) {
                             if (logger.isLoggable(Level.FINE)) {
                                 logger.log(Level.FINE, "Throwing InterruptedException with following message={0} " +
-                                                "for threadID={1}, threadName={2}",
-                                        new Object[]{ex.getMessage(), Thread.currentThread().getId(), Thread.currentThread().getName()});
+                                                "for threadID={1}, threadName={2}, , with requestId={3}",
+                                        new Object[]{ex.getMessage(), Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
                             }
                             wrapper.resumeOptimizedReadThreadInterrupted(ex);
                         }
@@ -764,10 +764,10 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
             // it will be the thread that executes the Work (messageMediator)we
             // put the on the WorkQueue here.
             if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, "Before to add messageMediator={0} to the queue={1} for threadID={2}, threadName={3}",
-                        new Object[]{messageMediator, queue, Thread.currentThread().getId(), Thread.currentThread().getName()});
+                logger.log(Level.FINE, "Before to add messageMediator={0} to the queue={1} for threadID={2}, threadName={3}, with requestId={3}",
+                        new Object[]{messageMediator, queue, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
             }
-            addMessageMediatorToWorkQueue(messageMediator);
+            addMessageMediatorToWorkQueue(messageMediator, requestId.toString());
         } else {
             if (logger.isLoggable(Level.FINE)) {
                 logger.log(Level.FINE, "No fragments to follow, continue with single processing for message={0} " +
@@ -790,7 +790,7 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
     private void poolToUseInfo( int id ) { }
 
     @Transport
-    private void addMessageMediatorToWorkQueue(final MessageMediator messageMediator) {
+    private void addMessageMediatorToWorkQueue(final MessageMediator messageMediator, final String requestId) {
         // Add messageMediator to work queue
         Throwable throwable = null;
         int poolToUse = -1;
@@ -798,27 +798,28 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
             poolToUse = messageMediator.getThreadPoolToUse();
             poolToUseInfo(poolToUse);
             if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, "Getting pool={0} to add messageMediator{1} for threadID={2}, theadName={3}",
-                        new Object[]{poolToUse, messageMediator, Thread.currentThread().getId(), Thread.currentThread().getName()});
+                logger.log(Level.FINE, "Adding messageMediator to pool={0} to add messageMediator{1} for threadID={2}, theadName={3}, requestId={4}",
+                        new Object[]{poolToUse, messageMediator, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
             }
             orb.getThreadPoolManager().getThreadPool(poolToUse).getWorkQueue(0).
                     addWork((MessageMediatorImpl) messageMediator);
             if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, "After adding messageMediator{0} for pool={1} with threadID={2}, theadName={3}",
-                        new Object[]{messageMediator, poolToUse, Thread.currentThread().getId(), Thread.currentThread().getName()});
+                logger.log(Level.FINE, "After adding messageMediator{0} for pool={1} with threadID={2}, theadName={3}, requestId={4}",
+                        new Object[]{messageMediator, poolToUse, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
             }
+            Thread.currentThread().notifyAll();
         } catch (NoSuchThreadPoolException e) {
             if (logger.isLoggable(Level.FINE)) {
                 logger.log(Level.FINE, "Throwing NoSuchThreadPoolException with following message={0} " +
-                                "for threadID={1}, theadName={2}",
-                        new Object[]{e.getMessage(), Thread.currentThread().getId(), Thread.currentThread().getName()});
+                                "for threadID={1}, theadName={2}, requestId={3}",
+                        new Object[]{e.getMessage(), Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
             }
             throwable = e;
         } catch (NoSuchWorkQueueException e) {
             if (logger.isLoggable(Level.FINE)) {
                 logger.log(Level.FINE, "Throwing NoSuchWorkQueueException with following message={0} " +
-                                "for threadID={1}, threadName={2}",
-                        new Object[]{e.getMessage(), Thread.currentThread().getId(), Thread.currentThread().getName()});
+                                "for threadID={1}, threadName={2}, requestId={3}",
+                        new Object[]{e.getMessage(), Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
             }
             throwable = e;
         }

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause OR GPL-2.0 WITH
  * Classpath-exception-2.0
  */
-// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2025] [Payara Foundation and/or its affiliates]
 
 package com.sun.corba.ee.impl.protocol;
 
@@ -29,6 +29,8 @@ import java.util.Iterator;
 import java.util.Queue;
 
 import com.sun.corba.ee.impl.protocol.giopmsgheaders.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.omg.CORBA.Any;
 import org.omg.CORBA.CompletionStatus;
 import org.omg.CORBA.ExceptionList;
@@ -93,18 +95,10 @@ import org.glassfish.pfl.tf.spi.annotation.InfoMethod;
  */
 @Subcontract
 @Transport
-public class MessageMediatorImpl
-    implements 
-        MessageMediator,
-        ProtocolHandler,
-        MessageHandler,
-        Work
-{
-    protected static final ORBUtilSystemException wrapper =
-        ORBUtilSystemException.self ;
-    protected static final InterceptorsSystemException interceptorWrapper =
-        InterceptorsSystemException.self ;
-
+public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, MessageHandler, Work {
+    private static final Logger logger = Logger.getLogger(MessageMediatorImpl.class.getName());
+    protected static final ORBUtilSystemException wrapper = ORBUtilSystemException.self;
+    protected static final InterceptorsSystemException interceptorWrapper = InterceptorsSystemException.self;
     protected ORB orb;
     protected ContactInfo contactInfo;
     protected Connection connection;
@@ -132,7 +126,7 @@ public class MessageMediatorImpl
 
     // The localMaxVersion is used for caching the value of 
     //MaxStreamFormatVersion if the ORB has been created by the app server  
-    private static byte localMaxVersion =  ORBUtility.getMaxStreamFormatVersion();
+    private static byte localMaxVersion = ORBUtility.getMaxStreamFormatVersion();
 
     // time this CorbaMessageMediator (Work) was added to a WorkQueue.
     private long enqueueTime;
@@ -140,23 +134,13 @@ public class MessageMediatorImpl
     //
     // Client-side constructor.
     //
-    public MessageMediatorImpl(ORB orb,
-                                    ContactInfo contactInfo,
-                                    Connection connection,
-                                    GIOPVersion giopVersion,
-                                    IOR ior,
-                                    int requestId,
-                                    short addrDisposition,
-                                    String operationName,
-                                    boolean isOneWay)
-    {
-        this( orb, connection ) ;
-            
+    public MessageMediatorImpl(ORB orb, ContactInfo contactInfo, Connection connection, GIOPVersion giopVersion,
+                               IOR ior, int requestId, short addrDisposition, String operationName, boolean isOneWay) {
+        this(orb, connection);
         this.contactInfo = contactInfo;
         this.addrDisposition = addrDisposition;
 
-        streamFormatVersion = getStreamFormatVersionForThisRequest(
-            this.contactInfo.getEffectiveTargetIOR(), giopVersion);
+        streamFormatVersion = getStreamFormatVersionForThisRequest(this.contactInfo.getEffectiveTargetIOR(), giopVersion);
 
         /* Assuming streamFormatVersion can be set to 2 here
          * here breaks interoperability
@@ -169,22 +153,21 @@ public class MessageMediatorImpl
 
         streamFormatVersionSet = true;
 
-        byte encodingVersion =
-            ORBUtility.chooseEncodingVersion(orb, ior, giopVersion);
+        byte encodingVersion = ORBUtility.chooseEncodingVersion(orb, ior, giopVersion);
         ORBUtility.pushEncVersionToThreadLocalState(encodingVersion);
-        requestHeader = MessageBase.createRequest(this.orb, giopVersion,
-            encodingVersion, requestId, !isOneWay,
-            this.contactInfo.getEffectiveTargetIOR(), this.addrDisposition,
-            operationName,
-            ServiceContextDefaults.makeServiceContexts(orb), null);
+        requestHeader = MessageBase.createRequest(this.orb, giopVersion, encodingVersion, requestId, !isOneWay,
+                this.contactInfo.getEffectiveTargetIOR(), this.addrDisposition,
+                operationName, ServiceContextDefaults.makeServiceContexts(orb), null);
     }
 
     //
     // Acceptor constructor.
     //
-    private MessageMediatorImpl(ORB orb,
-                                    Connection connection)
-    {
+    private MessageMediatorImpl(ORB orb, Connection connection) {
+        if (logger.isLoggable(Level.FINE)) {
+            logger.log(Level.FINE, "MessageMediatorImpl creation with connection={0} and orb={1}",
+                    new Object[]{connection, orb});
+        }
         this.orb = orb;
         this.connection = connection;
     }
@@ -196,12 +179,8 @@ public class MessageMediatorImpl
     // Note: in some cases (e.g., a reply message) this message 
     // mediator will only be used for dispatch.  Then the original 
     // request side mediator will take over. 
-    public MessageMediatorImpl(ORB orb,
-                                    Connection connection,
-                                    Message dispatchHeader,
-                                    ByteBuffer byteBuffer)
-    {
-        this( orb, connection ) ;
+    public MessageMediatorImpl(ORB orb, Connection connection, Message dispatchHeader, ByteBuffer byteBuffer) {
+        this(orb, connection);
         this.dispatchHeader = dispatchHeader;
         this.dispatchByteBuffer = byteBuffer;
     }
@@ -478,6 +457,9 @@ public class MessageMediatorImpl
             try {
                 InetSocketAddress connAddr = (InetSocketAddress) connection.getSocketChannel().getLocalAddress();
                 IIOPAddressImplLocalServer.setHostOverride(connAddr.getHostString());
+                if (logger.isLoggable(Level.FINE)) {
+                    logger.log(Level.FINE, "Connection information inetSocketAddress={0}", connAddr);
+                }
             }
             catch(IOException ex) {
                 throw wrapper.ioexceptionWhenReadingConnection(ex, connection);            
@@ -512,8 +494,7 @@ public class MessageMediatorImpl
         return true;
     }
 
-    public byte getStreamFormatVersion()
-    {
+    public byte getStreamFormatVersion() {
         // REVISIT: ContactInfo/Acceptor output object factories
         // just use this.  Maybe need to distinguish:
         //    createOutputObjectForRequest
@@ -689,6 +670,9 @@ public class MessageMediatorImpl
             dispatchHeader.callback(this);
         } catch (IOException e) {
             // REVISIT - this should be handled internally.
+            if (logger.isLoggable(Level.FINE)) {
+                logger.log(Level.FINE, "IOException with following message=", e.getMessage());
+            }
         } finally {
             ORBUtility.popEncVersionFromThreadLocalState();
         }
@@ -709,16 +693,20 @@ public class MessageMediatorImpl
 
     @Transport
     private void resumeOptimizedReadProcessing(Message message) {
-        messageInfo( message, message.getCorbaRequestId() ) ;
+        messageInfo(message, message.getCorbaRequestId());
         connectionInfo(connection);
 
         if (message.moreFragmentsToFollow()) {
+            if (logger.isLoggable(Level.FINE)) {
+                logger.log(Level.FINE,
+                        "Processing more fragments for message={0} fro threadID={1}",
+                        new Object[]{message, Thread.currentThread().getId()});
+            }
             generalMessage("getting next fragment");
 
             MessageMediator messageMediator = null;
             RequestId requestId = message.getCorbaRequestId();
-            Queue<MessageMediator> queue =
-                connection.getFragmentList(requestId);
+            Queue<MessageMediator> queue = connection.getFragmentList(requestId);
 
             // REVISIT - In the future, the synchronized(queue),
             // wait()/notify() construct should be replaced
@@ -730,13 +718,33 @@ public class MessageMediatorImpl
             // the synchronized(queue), wait(), notify()
             // implementation.
             synchronized (queue) {
+                if (logger.isLoggable(Level.FINE)) {
+                    logger.log(Level.FINE,
+                            "Thread accessing synchronized block, threadID={0} with requestId={1} and queue reference={2} and connection={3}",
+                            new Object[]{Thread.currentThread().getId(), requestId, queue.size() > 0 ? queue.element() : "", connection});
+                }
                 while (messageMediator == null) {
                     if (queue.size() > 0) {
                         messageMediator = queue.poll();
+                        if (logger.isLoggable(Level.FINE)) {
+                            logger.log(Level.FINE, "Current messageMediator={0} for threadID={1}",
+                                    new Object[]{messageMediator, Thread.currentThread().getId()});
+                        }
                     } else {
                         try {
+                            if (logger.isLoggable(Level.FINE)) {
+                                logger.log(Level.FINE,
+                                        "Starting to wait until available messageMediator on queue, threadID={0} " +
+                                                "and queue reference={1}",
+                                        new Object[]{Thread.currentThread().getId(), queue});
+                            }
                             queue.wait();
                         } catch (InterruptedException ex) {
+                            if (logger.isLoggable(Level.FINE)) {
+                                logger.log(Level.FINE, "Throwing InterruptedException with following message={0} " +
+                                                "for threadID={1}",
+                                        new Object[]{ex.getMessage(), Thread.currentThread().getId()});
+                            }
                             wrapper.resumeOptimizedReadThreadInterrupted(ex);
                         }
                     }
@@ -751,15 +759,23 @@ public class MessageMediatorImpl
             // thread is done processing the Work it was given, it is very likely
             // it will be the thread that executes the Work (messageMediator)we
             // put the on the WorkQueue here.
+            if (logger.isLoggable(Level.FINE)) {
+                logger.log(Level.FINE, "Before to add messageMediator={0} to the queue={1} for threadID={2}",
+                        new Object[]{messageMediator, queue, Thread.currentThread().getId()});
+            }
             addMessageMediatorToWorkQueue(messageMediator);
         } else {
-            if (message.getType() == Message.GIOPFragment || 
-                message.getType() == Message.GIOPCancelRequest) {
+            if (logger.isLoggable(Level.FINE)) {
+                logger.log(Level.FINE, "No fragments to follow, continue with single processing for message={0} and threadID={1}",
+                        new Object[]{message, Thread.currentThread().getId()});
+            }
+            if (message.getType() == Message.GIOPFragment ||
+                    message.getType() == Message.GIOPCancelRequest) {
                 // applies to FragmentMessage_1_[1|2] and CancelRequestMessage
                 // when using non-blocking NIO SocketChannels
                 RequestId requestId = message.getCorbaRequestId();
                 generalMessage(
-                    "done processing fragments (removing fragment list)" );
+                        "done processing fragments (removing fragment list)");
                 connection.removeFragmentList(requestId);
             }
         }
@@ -772,22 +788,40 @@ public class MessageMediatorImpl
     private void addMessageMediatorToWorkQueue(final MessageMediator messageMediator) {
         // Add messageMediator to work queue
         Throwable throwable = null;
-        int poolToUse = -1 ;
+        int poolToUse = -1;
         try {
             poolToUse = messageMediator.getThreadPoolToUse();
-            poolToUseInfo( poolToUse ) ;
+            poolToUseInfo(poolToUse);
+            if (logger.isLoggable(Level.FINE)) {
+                logger.log(Level.FINE, "Getting pool={0} to add messageMediator{1} for threadID={2}",
+                        new Object[]{poolToUse, messageMediator, Thread.currentThread().getId()});
+            }
             orb.getThreadPoolManager().getThreadPool(poolToUse).getWorkQueue(0).
-                             addWork((MessageMediatorImpl)messageMediator);
+                    addWork((MessageMediatorImpl) messageMediator);
+            if (logger.isLoggable(Level.FINE)) {
+                logger.log(Level.FINE, "After adding messageMediator{0} for pool={1} with threadID={2}",
+                        new Object[]{messageMediator, poolToUse, Thread.currentThread().getId()});
+            }
         } catch (NoSuchThreadPoolException e) {
+            if (logger.isLoggable(Level.FINE)) {
+                logger.log(Level.FINE, "Throwing NoSuchThreadPoolException with following message={0} " +
+                                "for threadID={1}",
+                        new Object[]{e.getMessage(), Thread.currentThread().getId()});
+            }
             throwable = e;
         } catch (NoSuchWorkQueueException e) {
+            if (logger.isLoggable(Level.FINE)) {
+                logger.log(Level.FINE, "Throwing NoSuchWorkQueueException with following message={0} " +
+                                "for threadID={1}",
+                        new Object[]{e.getMessage(), Thread.currentThread().getId()});
+            }
             throwable = e;
         }
 
         // REVISIT: need to close connection?
         if (throwable != null) {
             reportException("exception from thread pool", throwable);
-            throw wrapper.noSuchThreadpoolOrQueue(throwable, poolToUse );
+            throw wrapper.noSuchThreadpoolOrQueue(throwable, poolToUse);
         }
     }
 

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
@@ -102,12 +102,12 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
     private static final Logger logger = Logger.getLogger(MessageMediatorImpl.class.getName());
     protected static final ORBUtilSystemException wrapper = ORBUtilSystemException.self;
     protected static final InterceptorsSystemException interceptorWrapper = InterceptorsSystemException.self;
-    private static final String ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS = "fish.payara.corba.protocol.enablingNewFragmentProcess";
+    private static final String ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS = "com.sun.corba.ee.protocol.enablingNewFragmentProcess";
     private static final int DEFAULT_NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT = 10000;
     private static final boolean isNewFragmentProcessingSet = 
             Boolean.parseBoolean(System.getProperty(ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS) == null ? "false" : 
                     System.getProperty(ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS));
-    private static final String NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT = "fish.payara.corba.protocol.newFragmentEmptyConditionTimeout";
+    private static final String NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT = "com.sun.corba.ee.protocol.newFragmentEmptyConditionTimeout";
     private static final int newFragmentEmptyConditionTimeout = 
             System.getProperty(NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT) == null ? DEFAULT_NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT : 
                     Integer.parseInt(System.getProperty(NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT));
@@ -708,10 +708,12 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
         messageInfo(message, message.getCorbaRequestId());
         connectionInfo(connection);
 
-        if (message.moreFragmentsToFollow() && !isNewFragmentProcessingSet) {
-            synchronizedProcess(message);
-        } else if (message.moreFragmentsToFollow() && isNewFragmentProcessingSet) {
-            lockProcess(message);
+        if (message.moreFragmentsToFollow()) {
+            if (!isNewFragmentProcessingSet) {
+                synchronizedProcess(message);
+            } else {
+                lockProcess(message);
+            }
         } else {
             if (logger.isLoggable(Level.FINE)) {
                 logger.log(Level.FINE, "No fragments to follow, continue with single processing for message={0} " +
@@ -821,13 +823,13 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
                         new Object[]{Thread.currentThread().getId(), Thread.currentThread().getName(),
                                 requestId, queue.size() > 0 ? queue.size() : "", connection});
             }
-            
+
             while (messageMediator == null) {
                 if (queue.size() > 0) {
                     messageMediator = queue.poll();
                 } else {
-                    if(!queueStillEmpty){
-                       break;
+                    if (!queueStillEmpty) {
+                        break;
                     }
                     queueStillEmpty = queueEmptyCondition.await(newFragmentEmptyConditionTimeout, TimeUnit.MILLISECONDS);
                 }

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
@@ -104,8 +104,8 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
     protected static final InterceptorsSystemException interceptorWrapper = InterceptorsSystemException.self;
     private static final int DEFAULT_NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT = 10000;
     private static final boolean isNewFragmentProcessingSet = 
-            Boolean.parseBoolean(System.getProperty(ORBConstants.ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS) == null ? "false" : 
-                    System.getProperty(ORBConstants.ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS));
+            Boolean.parseBoolean(System.getProperty(ORBConstants.ENABLE_NEW_FRAGMENT_CONCURRENCY_PROCESS) == null ? "false" :
+                    System.getProperty(ORBConstants.ENABLE_NEW_FRAGMENT_CONCURRENCY_PROCESS));
     private static final int newFragmentEmptyConditionTimeout = 
             System.getProperty(ORBConstants.NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT) == null ? DEFAULT_NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT : 
                     Integer.parseInt(System.getProperty(ORBConstants.NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT));

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
@@ -29,6 +29,9 @@ import java.util.Iterator;
 import java.util.Queue;
 
 import com.sun.corba.ee.impl.protocol.giopmsgheaders.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.omg.CORBA.Any;
@@ -99,6 +102,8 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
     private static final Logger logger = Logger.getLogger(MessageMediatorImpl.class.getName());
     protected static final ORBUtilSystemException wrapper = ORBUtilSystemException.self;
     protected static final InterceptorsSystemException interceptorWrapper = InterceptorsSystemException.self;
+    private static final String ENABLING_NEW_FRAGMENT_CONCURRENCY_IMPL = "org.sun.corba.ee.impl.protocol.ENABLING_NEW_FRAGMENT_CONCURRENCY_IMPL";
+    private static final boolean isNewFragmentImplSet = Boolean.parseBoolean(System.getProperty(ENABLING_NEW_FRAGMENT_CONCURRENCY_IMPL) == null ? "false" : System.getProperty(ENABLING_NEW_FRAGMENT_CONCURRENCY_IMPL));
     protected ORB orb;
     protected ContactInfo contactInfo;
     protected Connection connection;
@@ -131,6 +136,8 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
     // time this CorbaMessageMediator (Work) was added to a WorkQueue.
     private long enqueueTime;
 
+    private ReentrantLock lock = new ReentrantLock();
+    private Condition queueEmptyCondition = lock.newCondition();
     //
     // Client-side constructor.
     //
@@ -164,11 +171,6 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
     // Acceptor constructor.
     //
     private MessageMediatorImpl(ORB orb, Connection connection) {
-        if (logger.isLoggable(Level.FINE)) {
-            logger.log(Level.FINE, "MessageMediatorImpl creation with connection={0} " +
-                            "and orb={1} and threadID={2} and threadName={3}",
-                    new Object[]{connection, orb, Thread.currentThread().getId(), Thread.currentThread().getName()});
-        }
         this.orb = orb;
         this.connection = connection;
     }
@@ -699,74 +701,10 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
         messageInfo(message, message.getCorbaRequestId());
         connectionInfo(connection);
 
-        if (message.moreFragmentsToFollow()) {
-            if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE,
-                        "Processing more fragments for message={0} for threadID={1}, threadName={2}",
-                        new Object[]{message, Thread.currentThread().getId(), Thread.currentThread().getName()});
-            }
-            generalMessage("getting next fragment");
-
-            MessageMediator messageMediator = null;
-            RequestId requestId = message.getCorbaRequestId();
-            Queue<MessageMediator> queue = connection.getFragmentList(requestId);
-
-            // REVISIT - In the future, the synchronized(queue),
-            // wait()/notify() construct should be replaced
-            // with something like a LinkedBlockingQueue
-            // from java.util.concurrent using its offer()
-            // and poll() methods.  But, at the time of the
-            // writing of this code, a LinkedBlockingQueue
-            // implementation is not performing as well as
-            // the synchronized(queue), wait(), notify()
-            // implementation.
-            synchronized (queue) {
-                if (logger.isLoggable(Level.FINE)) {
-                    logger.log(Level.FINE,
-                            "Thread accessing synchronized block, threadID={0}, threadName={1} with requestId={2} and queue reference={3} and connection={4}",
-                            new Object[]{Thread.currentThread().getId(), Thread.currentThread().getName(), 
-                                    requestId, queue.size() > 0 ? queue.element() : "", connection});
-                }
-                while (messageMediator == null) {
-                    if (queue.size() > 0) {
-                        messageMediator = queue.poll();
-                        if (logger.isLoggable(Level.FINE)) {
-                            logger.log(Level.FINE, "Current messageMediator={0} for threadID={1}, threadName={2}, with requestId={3}",
-                                    new Object[]{messageMediator, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
-                        }
-                    } else {
-                        try {
-                            if (logger.isLoggable(Level.FINE)) {
-                                logger.log(Level.FINE,
-                                        "Starting to wait until available messageMediator on queue, threadID={0}, threadName={1} " +
-                                                "and queue reference={2}, with requestId={3}",
-                                        new Object[]{Thread.currentThread().getId(), Thread.currentThread().getName(), queue, requestId});
-                            }
-                            queue.wait(1000);
-                        } catch (InterruptedException ex) {
-                            if (logger.isLoggable(Level.FINE)) {
-                                logger.log(Level.FINE, "Throwing InterruptedException with following message={0} " +
-                                                "for threadID={1}, threadName={2}, , with requestId={3}",
-                                        new Object[]{ex.getMessage(), Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
-                            }
-                            wrapper.resumeOptimizedReadThreadInterrupted(ex);
-                        }
-                    }
-                }
-            }
-            // Add CorbaMessageMediator to ThreadPool's WorkQueue to process the
-            // next fragment.
-            // Although we could call messageMeditor.doWork() rather than putting
-            // the messageMediator on the WorkQueue, we do not because calling
-            // doWork() would increase the depth of the call stack. Since this
-            // thread is done processing the Work it was given, it is very likely
-            // it will be the thread that executes the Work (messageMediator)we
-            // put the on the WorkQueue here.
-            if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, "Before to add messageMediator={0}, threadID={1}, threadName={2}, with requestId={3}",
-                        new Object[]{messageMediator, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
-            }
-            addMessageMediatorToWorkQueue(messageMediator, requestId.toString());
+        if (message.moreFragmentsToFollow() && !isNewFragmentImplSet) {
+            legacySyncronizedProcess(message);
+        } else if (message.moreFragmentsToFollow() && isNewFragmentImplSet) {
+            newLockProcess(message);
         } else {
             if (logger.isLoggable(Level.FINE)) {
                 logger.log(Level.FINE, "No fragments to follow, continue with single processing for message={0} " +
@@ -782,6 +720,137 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
                         "done processing fragments (removing fragment list)");
                 connection.removeFragmentList(requestId);
             }
+        }
+    }
+
+    private void legacySyncronizedProcess(Message message) {
+        if (logger.isLoggable(Level.FINE)) {
+            logger.log(Level.FINE,
+                    "Processing more fragments using legacy synchronized method for message={0} for threadID={1}, threadName={2}",
+                    new Object[]{message, Thread.currentThread().getId(), Thread.currentThread().getName()});
+        }
+        generalMessage("getting next fragment");
+
+        MessageMediator messageMediator = null;
+        RequestId requestId = message.getCorbaRequestId();
+        Queue<MessageMediator> queue = connection.getFragmentList(requestId);
+
+        // REVISIT - In the future, the synchronized(queue),
+        // wait()/notify() construct should be replaced
+        // with something like a LinkedBlockingQueue
+        // from java.util.concurrent using its offer()
+        // and poll() methods.  But, at the time of the
+        // writing of this code, a LinkedBlockingQueue
+        // implementation is not performing as well as
+        // the synchronized(queue), wait(), notify()
+        // implementation.
+        synchronized (queue) {
+            if (logger.isLoggable(Level.FINE)) {
+                logger.log(Level.FINE,
+                        "Thread accessing synchronized block, threadID={0}, threadName={1} with requestId={2} and queue reference={3} and connection={4}",
+                        new Object[]{Thread.currentThread().getId(), Thread.currentThread().getName(),
+                                requestId, queue.size() > 0 ? queue.element() : "", connection});
+            }
+            while (messageMediator == null) {
+                if (queue.size() > 0) {
+                    messageMediator = queue.poll();
+                } else {
+                    try {
+                        if (logger.isLoggable(Level.FINE)) {
+                            logger.log(Level.FINE,
+                                    "Starting to wait until available messageMediator on queue, threadID={0}, threadName={1} " +
+                                            "and queue reference={2}, with requestId={3}",
+                                    new Object[]{Thread.currentThread().getId(), Thread.currentThread().getName(), queue, requestId});
+                        }
+                        queue.wait();
+                    } catch (InterruptedException ex) {
+                        if (logger.isLoggable(Level.FINE)) {
+                            logger.log(Level.FINE, "Throwing InterruptedException with following message={0} " +
+                                            "for threadID={1}, threadName={2}, , with requestId={3}",
+                                    new Object[]{ex.getMessage(), Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
+                        }
+                        wrapper.resumeOptimizedReadThreadInterrupted(ex);
+                    }
+                }
+            }
+        }
+        // Add CorbaMessageMediator to ThreadPool's WorkQueue to process the
+        // next fragment.
+        // Although we could call messageMeditor.doWork() rather than putting
+        // the messageMediator on the WorkQueue, we do not because calling
+        // doWork() would increase the depth of the call stack. Since this
+        // thread is done processing the Work it was given, it is very likely
+        // it will be the thread that executes the Work (messageMediator)we
+        // put the on the WorkQueue here.
+        if (logger.isLoggable(Level.FINE)) {
+            logger.log(Level.FINE, "Before to add messageMediator={0}, threadID={1}, threadName={2}, with requestId={3}",
+                    new Object[]{messageMediator, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
+        }
+        addMessageMediatorToWorkQueue(messageMediator, requestId.toString());
+    }
+
+    private void newLockProcess(Message message) {
+        if (logger.isLoggable(Level.FINE)) {
+            logger.log(Level.FINE,
+                    "Processing more fragments using new lock method for message={0} for threadID={1}, threadName={2}",
+                    new Object[]{message, Thread.currentThread().getId(), Thread.currentThread().getName()});
+        }
+        generalMessage("getting next fragment");
+
+        MessageMediator messageMediator = null;
+        RequestId requestId = message.getCorbaRequestId();
+        try {
+            boolean queueStillEmpty = true;
+            lock.lock();
+            if (logger.isLoggable(Level.FINE)) {
+                logger.log(Level.FINE, 
+                        "Lock acquired for threadId={0}, threadName={1} with requestId={2}", 
+                        new Object[] { Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
+            }
+            Queue<MessageMediator> queue = connection.getFragmentList(requestId);
+            if (logger.isLoggable(Level.FINE)) {
+                logger.log(Level.FINE,
+                        "Thread accessing locked block, threadID={0}, threadName={1} with requestId={2} and queue size={3} and connection={4}",
+                        new Object[]{Thread.currentThread().getId(), Thread.currentThread().getName(),
+                                requestId, queue.size() > 0 ? queue.size() : "", connection});
+            }
+            
+            while (messageMediator == null) {
+                if (queue.size() > 0) {
+                    messageMediator = queue.poll();
+                } else {
+                    if(!queueStillEmpty){
+                       break;
+                    }
+                    queueStillEmpty = queueEmptyCondition.await(1000, TimeUnit.MILLISECONDS);
+                }
+            }
+        } catch (InterruptedException e) {
+            if (logger.isLoggable(Level.FINE)) {
+                logger.log(Level.FINE, "Throwing interrupted exception for threadId={0} and requestId={1}", 
+                        new Object[] {Thread.currentThread().getId(), requestId});
+            }
+        } finally {
+            lock.unlock();
+            if (logger.isLoggable(Level.FINE)) {
+                logger.log(Level.FINE, "Leaving the lock from MessageMediator with Fragments for threadId={0} and requestId={1}", 
+                        new Object[] {Thread.currentThread().getId(), requestId});
+            }
+        }
+        // Add CorbaMessageMediator to ThreadPool's WorkQueue to process the
+        // next fragment.
+        // Although we could call messageMeditor.doWork() rather than putting
+        // the messageMediator on the WorkQueue, we do not because calling
+        // doWork() would increase the depth of the call stack. Since this
+        // thread is done processing the Work it was given, it is very likely
+        // it will be the thread that executes the Work (messageMediator)we
+        // put the on the WorkQueue here.
+        if (logger.isLoggable(Level.FINE)) {
+            logger.log(Level.FINE, "Before to add messageMediator={0}, threadID={1}, threadName={2}, with requestId={3}",
+                    new Object[]{messageMediator, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
+        }
+        if (messageMediator != null) {
+            addMessageMediatorToWorkQueue(messageMediator, requestId.toString());
         }
     }
 
@@ -806,7 +875,6 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
                 logger.log(Level.FINE, "After adding messageMediator={0} to pool={1} with threadID={2}, theadName={3}, requestId={4}",
                         new Object[]{messageMediator, poolToUse, Thread.currentThread().getId(), Thread.currentThread().getName(), requestId});
             }
-            Thread.currentThread().notifyAll();
         } catch (NoSuchThreadPoolException e) {
             if (logger.isLoggable(Level.FINE)) {
                 logger.log(Level.FINE, "Throwing NoSuchThreadPoolException with following message={0} " +

--- a/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/impl/protocol/MessageMediatorImpl.java
@@ -102,15 +102,13 @@ public class MessageMediatorImpl implements MessageMediator, ProtocolHandler, Me
     private static final Logger logger = Logger.getLogger(MessageMediatorImpl.class.getName());
     protected static final ORBUtilSystemException wrapper = ORBUtilSystemException.self;
     protected static final InterceptorsSystemException interceptorWrapper = InterceptorsSystemException.self;
-    private static final String ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS = "com.sun.corba.ee.protocol.enablingNewFragmentProcess";
     private static final int DEFAULT_NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT = 10000;
     private static final boolean isNewFragmentProcessingSet = 
-            Boolean.parseBoolean(System.getProperty(ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS) == null ? "false" : 
-                    System.getProperty(ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS));
-    private static final String NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT = "com.sun.corba.ee.protocol.newFragmentEmptyConditionTimeout";
+            Boolean.parseBoolean(System.getProperty(ORBConstants.ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS) == null ? "false" : 
+                    System.getProperty(ORBConstants.ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS));
     private static final int newFragmentEmptyConditionTimeout = 
-            System.getProperty(NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT) == null ? DEFAULT_NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT : 
-                    Integer.parseInt(System.getProperty(NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT));
+            System.getProperty(ORBConstants.NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT) == null ? DEFAULT_NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT : 
+                    Integer.parseInt(System.getProperty(ORBConstants.NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT));
     protected ORB orb;
     protected ContactInfo contactInfo;
     protected Connection connection;

--- a/orbmain/src/main/java/com/sun/corba/ee/spi/misc/ORBConstants.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/spi/misc/ORBConstants.java
@@ -17,6 +17,8 @@
  * Classpath-exception-2.0
  */
 
+// Portions Copyright [2025] [Payara Foundation and/or its affiliates]
+
 package com.sun.corba.ee.spi.misc;
 
 import com.sun.corba.ee.org.omg.CORBA.SUNVMCID ;

--- a/orbmain/src/main/java/com/sun/corba/ee/spi/misc/ORBConstants.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/spi/misc/ORBConstants.java
@@ -620,7 +620,7 @@ public class ORBConstants {
         + "ORBGmbalRootParentName" ;
     
     //protocol constants to enable new lock api mechanism to process fragments 
-    public static final String ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS = SUN_PREFIX + "protocol.enablingNewFragmentProcess";
+    public static final String ENABLE_NEW_FRAGMENT_CONCURRENCY_PROCESS = SUN_PREFIX + "protocol.enableNewFragmentProcess";
     public static final String NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT = SUN_PREFIX + "protocol.newFragmentEmptyConditionTimeout";
 }
 

--- a/orbmain/src/main/java/com/sun/corba/ee/spi/misc/ORBConstants.java
+++ b/orbmain/src/main/java/com/sun/corba/ee/spi/misc/ORBConstants.java
@@ -616,6 +616,10 @@ public class ORBConstants {
     // ORB's gmbal root.
     public static final String GMBAL_ROOT_PARENT_NAME = SUN_PREFIX 
         + "ORBGmbalRootParentName" ;
+    
+    //protocol constants to enable new lock api mechanism to process fragments 
+    public static final String ENABLING_NEW_FRAGMENT_CONCURRENCY_PROCESS = SUN_PREFIX + "protocol.enablingNewFragmentProcess";
+    public static final String NEW_FRAGMENT_EMPTY_CONDITION_TIMEOUT = SUN_PREFIX + "protocol.newFragmentEmptyConditionTimeout";
 }
 
 // End of file.

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.glassfish.corba</groupId>
     <artifactId>glassfish-corba</artifactId>
-    <version>4.2.4.payara-p4-SNAPSHOT</version>
+    <version>4.2.4.payara-p3</version>
     <name>ORB Implementation</name>
     <packaging>pom</packaging>
     <description>A CORBA ORB for Glassfish</description>

--- a/pom.xml
+++ b/pom.xml
@@ -444,5 +444,66 @@
           <modules>
               <module>functional-tests</module>
           </modules>
-        </profile>    </profiles>
+        </profile>
+        <profile>
+            <id>patched-project-release</id>
+            <distributionManagement>
+                <repository>
+                    <id>payara-nexus-artifacts</id>
+                    <url>https://nexus.dev.payara.fish/repository/payara-artifacts/</url>
+                </repository>
+                <snapshotRepository>
+                    <id>payara-nexus-snapshots</id>
+                    <url>https://nexus.dev.payara.fish/repository/payara-snapshots/</url>
+                </snapshotRepository>
+            </distributionManagement>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.glassfish.corba</groupId>
     <artifactId>glassfish-corba</artifactId>
-    <version>4.2.4.payara-p3</version>
+    <version>4.2.4.payara-p4-SNAPSHOT</version>
     <name>ORB Implementation</name>
     <packaging>pom</packaging>
     <description>A CORBA ORB for Glassfish</description>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.glassfish.corba</groupId>
     <artifactId>glassfish-corba</artifactId>
-    <version>4.2.4.payara-p3</version>
+    <version>4.2.4.payara-p3-SNAPSHOT</version>
     <name>ORB Implementation</name>
     <packaging>pom</packaging>
     <description>A CORBA ORB for Glassfish</description>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.glassfish.corba</groupId>
     <artifactId>glassfish-corba</artifactId>
-    <version>4.2.4.payara-p4-SNAPSHOT</version>
+    <version>4.2.4.payara-p3-SNAPSHOT</version>
     <name>ORB Implementation</name>
     <packaging>pom</packaging>
     <description>A CORBA ORB for Glassfish</description>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.glassfish.corba</groupId>
     <artifactId>glassfish-corba</artifactId>
-    <version>4.2.4.payara-p3-SNAPSHOT</version>
+    <version>4.2.4.payara-p3</version>
     <name>ORB Implementation</name>
     <packaging>pom</packaging>
     <description>A CORBA ORB for Glassfish</description>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.glassfish.corba</groupId>
     <artifactId>glassfish-corba</artifactId>
-    <version>4.2.4.payara-p3-SNAPSHOT</version>
+    <version>4.2.4.payara-p4-SNAPSHOT</version>
     <name>ORB Implementation</name>
     <packaging>pom</packaging>
     <description>A CORBA ORB for Glassfish</description>

--- a/rmic/pom.xml
+++ b/rmic/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3-SNAPSHOT</version>
+        <version>4.2.4.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>rmic</artifactId>

--- a/rmic/pom.xml
+++ b/rmic/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p4-SNAPSHOT</version>
+        <version>4.2.4.payara-p3</version>
     </parent>
 
     <artifactId>rmic</artifactId>

--- a/rmic/pom.xml
+++ b/rmic/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3</version>
+        <version>4.2.4.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>rmic</artifactId>

--- a/rmic/pom.xml
+++ b/rmic/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3</version>
+        <version>4.2.4.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>rmic</artifactId>

--- a/rmic/pom.xml
+++ b/rmic/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p4-SNAPSHOT</version>
+        <version>4.2.4.payara-p3-SNAPSHOT</version>
     </parent>
 
     <artifactId>rmic</artifactId>

--- a/rmic/pom.xml
+++ b/rmic/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.corba</groupId>
         <artifactId>glassfish-corba</artifactId>
-        <version>4.2.4.payara-p3-SNAPSHOT</version>
+        <version>4.2.4.payara-p3</version>
     </parent>
 
     <artifactId>rmic</artifactId>


### PR DESCRIPTION
This is to improve the current implementation to instead of using synchronized blocks to prevent concurrent threads to access resources, now use lock api. We decided to improve because with synchronized it is hard to determine which thread access and release the resources. Here I list the advantages to use the lock api:

1. Fine-Grained control: We are doing explicit locking and unlocking, this is more precise and efficient than the implementation with synchronized
2. Use of conditions variables: This allow threads to wait for certain conditions to be met before proceeding
3. Multiple Object locking: lock can be shared among multiple class instances, allowing you to manage synchronization across
these instances more flexible

For the tests I created the following Remote EJB:
[remoteview.zip](https://github.com/user-attachments/files/19060987/remoteview.zip)

To use you need to deploy on the server and include this jar on an standalone java application, here included also:
[EJBRemoteClient6.zip](https://github.com/user-attachments/files/19060999/EJBRemoteClient6.zip)

On the Main class you will see the remote call configuration to execute the tests with multiple threads creating 300 requests to the server. Something important for the standalone application is to indicate the correct path for the modules folder and resolve all dependencies for the EJB Client call configuration:

![image](https://github.com/user-attachments/assets/dfe77ac6-207d-4954-929d-ac8a584c920f)

to enable the new implementation with locks you need to set the following property on the system:

`com.sun.corba.ee.protocol.enablingNewFragmentProcess=true`

by default this is set as false to use the synchonized mechanism

also you can set the timeout time of the internal management of the process to wait for information on the queue with the following property:

`com.sun.corba.ee.protocol.newFragmentEmptyConditionTimeout=10000`

by default this is set with 10000 milliseconds, the unit for the value is milliseconds and this value is only used when the previous property is set as true

after doing multiple calls using the reproducer now I can't see any affectation on the threads, now all of them are finishing and also the performance is not affected:

![image](https://github.com/user-attachments/assets/bbd3ca49-2a60-4698-8299-7ebac2e18a1c)


I used the following environment for testing: Payara 6, azul JDK 11, windows 11 and maven 3.8.6